### PR TITLE
Fixed Windows Builder Script -_-

### DIFF
--- a/pw4_oop/build.bat
+++ b/pw4_oop/build.bat
@@ -11,9 +11,9 @@ set "RED=%ESC%[91m"
 set "RESET=%ESC%[0m"
 
 :: Welcome message
-echo %CYAN%======================================%RESET%
-echo %CYAN%| PW 4 Java Builder && Runner Script |%RESET%
-echo %CYAN%======================================%RESET%
+echo "%CYAN%======================================%RESET%"
+echo "%CYAN%| PW 4 Java Builder && Runner Script |%RESET%"
+echo "%CYAN%======================================%RESET%"
 echo.
 
 :: Create output directory
@@ -21,9 +21,12 @@ if not exist out (
     mkdir out
 )
 
-:: Compile Java files
+:: Compile Java files (recursively)
 echo %YELLOW%Compiling Java files...%RESET%
-javac -d out .\src\*.java
+for /R src %%f in (*.java) do (
+    set "srcfiles=!srcfiles! %%f"
+)
+javac -d out !srcfiles!
 if errorlevel 1 (
     echo %RED%Compilation failed! Please check your code.%RESET%
     pause
@@ -59,4 +62,3 @@ if "%choice%"=="1" (
 )
 
 pause
-goto MENU


### PR DESCRIPTION
This pull request updates the `pw4_oop/build.bat` script to enhance its functionality and fix minor formatting issues. The most notable changes include enabling recursive Java file compilation and addressing inconsistencies in the echo statements.

### Enhancements to functionality:
* Updated the Java compilation process to recursively include all `.java` files in the `src` directory, improving support for projects with nested package structures.

### Formatting improvements:
* Adjusted the echo statements to include quotes around the `%CYAN%` and `%RESET%` variables for consistency and to prevent potential parsing issues.

### Code cleanup:
* Removed an unnecessary `goto MENU` statement at the end of the script, streamlining the code.

Closes #4 

